### PR TITLE
Map module support and deprecate store logic, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,36 @@ In order to poll the substream, you will need to call the `poll()` function on t
 # View available modules on .spkg
 print(sb.output_modules)
 
-# Poll the module and return a list of SubstreamOutput objects in the order of teh specified modules
+# Poll the module and return a list of SubstreamOutput objects in the order of the specified modules
 result = sb.poll(["store_swap_events"], start_block=10000835, end_block=10000835+20000)
 ```
 
-The result here is a `SubstreamOutput` object, you can access both the `data` and `snapshots` dataframes by doing:
+With the default inputs, this function outputs Pandas Dataframes after streaming all blocks between the start_block and end_block. However depending on how this function is called, a dict object is returned. The `poll()` function has a number of inputs
+
+- output_modules
+    - List of strings of output modules to stream 
+- start_block
+    - Integer block number to start the polling
+- end_block
+    - Integer block number to end the polling. In theory, there is no max block number as any block number past chain head will stream the blocks in real time. Its recommended to use an end_block far off into the future if building a data app that will be streaming datain real time as blocks finalize, such as block 20,000,000
+- stream_callback
+    - An optional callback function to be passed into the polling function to execute when valid streamed data is received 
+- return_first_result
+    - Boolean value that if True will return data on the first block after the start block to have an applicable TX/Event.
+    - Can be called recursively on the front end while incrementing the start_block to return data as its streamed rather than all data at once after streaming is completed
+    - Defaults to False
+    - If True, the data is returned in the format {"data": [], "module_name": String, "data_block": int}
+- initial_snapshot
+    - Boolean value, defaults to False
+- highest_processed_block
+    - Integer block number that is used in measuring indexing and processing progress, in cases where return_progress is True
+    - Defaults to 0
+- return_progress: bool = False,
+    - Boolean value that if True returns progress in back processing
+    - Defaults to False
+
+
+The result here is the default `SubstreamOutput` object, you can access both the `data` and `snapshots` dataframes by doing:
 
 ```python
 # These will return pandas DataFrames

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "substreams"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Ryan Sudhakaran", email="ryan.sudhakaran@messari.io" },
   { name="Michael Carroll", email="michaelcarroll1999@gmail.com" },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="substreams",
-    version="0.0.6",
+    version="0.0.7",
     packages=[".substreams"],
     author="Ryan Sudhakaran",
     author_email="ryan.sudhakaran@messari.io",


### PR DESCRIPTION
-Added further poll() documentation to readme
-Data output module name must be in the list of output_modules passed to the poll() function to enforce data consistency
-Deprecate store module logicin poll() as the store modules no longer output data in default running configs
-Basic cleanup and logic refactoring

 