### PR TITLE
Return type refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,33 +39,27 @@ In order to poll the substream, you will need to call the `poll()` function on t
 print(sb.output_modules)
 
 # Poll the module and return a list of SubstreamOutput objects in the order of the specified modules
-result = sb.poll(["store_swap_events"], start_block=10000835, end_block=10000835+20000)
+result = sb.poll(["map_swap_events"], start_block=10000835, end_block=10000835+20000)
 ```
 
 With the default inputs, this function outputs Pandas Dataframes after streaming all blocks between the start_block and end_block. However depending on how this function is called, a dict object is returned. The `poll()` function has a number of inputs
 
 - output_modules
-    - List of strings of output modules to stream 
+    - String of the output module to stream 
 - start_block
     - Integer block number to start the polling
 - end_block
     - Integer block number to end the polling. In theory, there is no max block number as any block number past chain head will stream the blocks in real time. Its recommended to use an end_block far off into the future if building a data app that will be streaming datain real time as blocks finalize, such as block 20,000,000
-- stream_callback
-    - An optional callback function to be passed into the polling function to execute when valid streamed data is received 
 - return_first_result
     - Boolean value that if True will return data on the first block after the start block to have an applicable TX/Event.
     - Can be called recursively on the front end while incrementing the start_block to return data as its streamed rather than all data at once after streaming is completed
     - Defaults to False
-    - If True, the data is returned in the format {"data": [], "module_name": String, "data_block": int}
 - initial_snapshot
     - Boolean value, defaults to False
-- highest_processed_block
-    - Integer block number that is used in measuring indexing and processing progress, in cases where return_progress is True
-    - Defaults to 0
-- return_progress: bool = False,
-    - Boolean value that if True returns progress in back processing
-    - Defaults to False
-
+- return_type
+    - Specifies the type of value to return
+    - Passing "df" returns the data in a pandas DataFrame
+    - Passing "dict" returns in the format {"data": [], "module_name": String, "data_block": int, error: str | None}
 
 The result here is the default `SubstreamOutput` object, you can access both the `data` and `snapshots` dataframes by doing:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to poll the substream, you will need to call the `poll()` function on t
 print(sb.output_modules)
 
 # Poll the module and return a list of SubstreamOutput objects in the order of the specified modules
-result = sb.poll(["map_swap_events"], start_block=10000835, end_block=10000835+20000)
+result = sb.poll("map_swap_events", start_block=10000835, end_block=10000835+20000)
 ```
 
 With the default inputs, this function outputs Pandas Dataframes after streaming all blocks between the start_block and end_block. However depending on how this function is called, a dict object is returned. The `poll()` function has a number of inputs


### PR DESCRIPTION
-Change poll() func output_modules param from str[] to output_module as a single string (running a substream on two+ modules at the same time is no longer possible)
-Add poll() func return_type parameter to select the format of the function output and new logic to support this
-Delete deprecated poll() paramters
-Further error handling
-Condense and simplify return logic